### PR TITLE
README example numbering and import consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ var MyOtherType = Ember.Object.extend({
 ````
 You can use `literal` in your project two ways
 
-1. Use it via the `Ember` namespace
+1) Use it via the `Ember` namespace
 ````javascript
 Ember.literal
 ````
-2. Import the macro directly
+2) Import the macro directly
 ````javascript
-import literal from 'ember-literal/macros/literal';
+import l from 'ember-literal/macros/literal';
 ````
 
 ## CDN


### PR DESCRIPTION
GitHub was automatically rendering the numbering of the second entry as a 1 again, because of the "special" syntax.

Additionally, change the example import from `literal` to `l` to match the import used in the previous example above it.